### PR TITLE
Added configuration for custom sufixes/salutations/compound adds and ignores

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,11 +6,38 @@ function diff(a1, a2) {
 	});
 }
 
-parser.parseName = function (name, ignoreSuffix) {
-	if (!ignoreSuffix) ignoreSuffix = []
-	const salutations = ['mr', 'master', 'mister', 'mrs', 'miss', 'ms', 'dr', 'prof', 'rev', 'fr', 'judge', 'honorable', 'hon', 'tuan', 'sr', 'srta', 'br', 'pr', 'mx', 'sra'];
-	const suffixes = ['i', 'ii', 'iii', 'iv', 'v', 'senior', 'junior', 'jr', 'sr', 'phd', 'apr', 'rph', 'pe', 'md', 'ma', 'dmd', 'cme', 'qc', 'kc'].filter(suffix => !ignoreSuffix.includes(suffix));
-	const compound = ['vere', 'von', 'van', 'de', 'del', 'della', 'der', 'den', 'di', 'da', 'pietro', 'vanden', 'du', 'st.', 'st', 'la', 'lo', 'ter', 'bin', 'ibn', 'te', 'ten', 'op', 'ben', 'al'];
+const lc = value => value.toLowerCase();
+
+parser.parseName = function (name, opts = {}) {
+	let extraCompound = [];
+	let extraSalutations = [];
+	let extraSuffixes = [];
+	let ignoreCompound = [];
+	let ignoreSalutation = [];
+	let ignoreSuffix = [];
+
+	if (Array.isArray(opts)) {
+		ignoreSuffix = opts.map(v => v.toLowerCase());
+	} else {
+		({
+			extraCompound = [],
+			extraSalutations = [], 
+			extraSuffixes = [], 
+			ignoreCompound = [],
+			ignoreSalutation = [],
+			ignoreSuffix = []
+		} = opts);
+
+		extraCompound = extraCompound.map(lc);
+		extraSalutations = extraSalutations.map(lc);
+		extraSuffixes = extraSuffixes.map(lc);
+		ignoreCompound = ignoreCompound.map(lc);
+		ignoreSalutation = ignoreSalutation.map(lc);
+		ignoreSuffix = ignoreSuffix.map(lc);
+	}
+	const salutations = ['mr', 'master', 'mister', 'mrs', 'miss', 'ms', 'dr', 'prof', 'rev', 'fr', 'judge', 'honorable', 'hon', 'tuan', 'sr', 'srta', 'br', 'pr', 'mx', 'sra', ...extraSalutations].filter(salutation => !ignoreSalutation.includes(salutation));
+	const suffixes = ['i', 'ii', 'iii', 'iv', 'v', 'senior', 'junior', 'jr', 'sr', 'phd', 'apr', 'rph', 'pe', 'md', 'ma', 'dmd', 'cme', 'qc', 'kc', ...extraSuffixes].filter(suffix => !ignoreSuffix.includes(suffix));
+	const compound = ['vere', 'von', 'van', 'de', 'del', 'della', 'der', 'den', 'di', 'da', 'pietro', 'vanden', 'du', 'st.', 'st', 'la', 'lo', 'ter', 'bin', 'ibn', 'te', 'ten', 'op', 'ben', 'al', ...extraCompound].filter(compound => !ignoreCompound.includes(compound));
 
 	let parts = name
 		.trim()

--- a/test/index.js
+++ b/test/index.js
@@ -248,6 +248,79 @@ describe('Parsing names', () => {
 		}
 	];
 
+	const extras = [
+		{
+			name: 'John Jones 3rd',
+			opts: {
+				extraSuffixes: ['3rd']
+			},
+			result: {
+				firstName: 'John',
+				lastName: 'Jones',
+				suffix: '3rd',
+				fullName: 'John Jones 3rd'
+			}
+		},
+		{
+			name: 'Doc Emmett Brown',
+			opts: {
+				extraSalutations: ['Doc']
+			},
+			result: {
+				firstName: 'Emmett',
+				lastName: 'Brown',
+				salutation: 'Doc',
+				fullName: 'Doc Emmett Brown'
+			}
+		},
+		{
+			name: 'Marcy Tre Lane',
+			opts: {
+				extraCompound: ['Tre']
+			},
+			result: {
+				firstName: 'Marcy',
+				lastName: 'Tre Lane',
+				fullName: 'Marcy Tre Lane'
+			}
+		},
+		{
+			name: 'John Jones Jr',
+			opts: {
+				ignoreSuffix: ['Jr']
+			},
+			result: {
+				firstName: 'John',
+				middleName: 'Jones',
+				lastName: 'Jr',
+				fullName: 'John Jones Jr'
+			}
+		},
+		{
+			name: 'Mister T',
+			opts: {
+				ignoreSalutation: ['Mister']
+			},
+			result: {
+				firstName: 'Mister',
+				lastName: 'T',
+				fullName: 'Mister T'
+			}
+		},
+		{
+			name: 'William De La Cruz',
+			opts: {
+				ignoreCompound: ['De']
+			},
+			result: {
+				firstName: 'William',
+				lastName: 'La Cruz',
+				middleName: 'De',
+				fullName: 'William De La Cruz'
+			}
+		}
+	];
+
 	const addresses = [
 		{
 			address: '123 W. Happy Day Blvd., San Francisco, CA  90501',
@@ -302,6 +375,14 @@ describe('Parsing names', () => {
 			const fullName = human.getFullestName(name.name);
 
 			expect(name.result.fullName).to.eql(fullName);
+		});
+	});
+
+	it('Should parse names using extra configuration', () => {
+		extras.forEach((name, i, list) => {
+			const parsed = human.parseName(name.name, name.opts);
+
+			expect(name.result).to.eql(parsed);
 		});
 	});
 


### PR DESCRIPTION
Kept the signature for `ignoreSuffix` the same for backward compatibility, but added in support for a configuration object for the second argument to provide custom suffix/salutation/compound list, plus the ability to provide custom ignore lists for each. Also, auto-handle lower casing extras/ignores to prevent frustration